### PR TITLE
Update ext/xxHash to v0.8.0

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,7 +1,27 @@
 use strict;
 use Module::Build;
 
-my $build = Module::Build->new(
+# Annoyingly with 'c_source' Module::Build can *only* add entire directory
+# *trees* recursively. This (no longer) works for xxHash, because their checkout
+# now contains a subdirectory with test programs, including multiple definitions
+# of main(), and the naive Module::Build approach attempts to link all object
+# files into one shared library, which isn't going to work in that case.
+# So we have to hack it. Grrr.
+my $class = Module::Build->subclass (
+    class => 'My::Builder',
+    code => <<'EOC',
+
+sub process_support_files {
+    my $self = shift;
+    my $p = $self->{properties};
+    push @{$p->{objects}}, $self->compile_c('ext/xxHash/xxhash.c');
+    return $self->SUPER::process_support_files(@_);
+}
+
+EOC
+);
+
+my $build = $class->new(
     module_name         => 'Digest::xxHash',
     license             => 'bsd',
     create_readme       => 1,
@@ -18,8 +38,8 @@ my $build = Module::Build->new(
     needs_compiler => 1,
     #extra_compiler_flags => ['-Wall -W -Wundef -Wno-implicit-function-declaration'],
     #extra_linker_flags => [ ],
-    include_dirs   => ['.'],
-    c_source       => ['ext/xxHash', 'ext/perl_math_int64'],
+    include_dirs   => ['.', 'ext/xxHash'],
+    c_source       => ['ext/perl_math_int64'],
     xs_files       => {
         './xxHash.xs' => 'lib/Digest/xxHash.xs' 
     },

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Changes
 =======
 
+2.05 - 21 August 2020
+  * Update xxHash lib to v0.8.0 (July 27th, 2020)
+
 2.04 - 05 September 2019
   * Fix mishandling unsigned 64bit integers when moving from XS to pure Perl
   * Prepend zeros to hex values

--- a/lib/Digest/xxHash.pm
+++ b/lib/Digest/xxHash.pm
@@ -6,7 +6,7 @@ use XSLoader;
 use Math::Int64 qw[uint64_to_hex];
 
 BEGIN {
-    our $VERSION = '2.04';
+    our $VERSION = '2.05';
     XSLoader::load __PACKAGE__, $VERSION;
 }
 our @EXPORT_OK = qw[xxhash32 xxhash32_hex


### PR DESCRIPTION
These changes update the ext/xxHash to v0.8.0 and fix the build problems that this causes.

As documented in the commit, upstream xxHash has added a subtree containing C test files. The way Module::Build is implemented, `c_source` can only add a tree *recursively*, meaning that it will spot all these new files, and attempt to compile and link them all. This breaks.

Having asked on #toolchain for advice, Leon Timmermans suggests that the easiest way to keep the current structure (the entirety of xxHash checked out) is to subclass Module::Build and special case `process_support_files`. So this is what I have done.

Passes tests on 3 different Linux architectures, which roughly the limit of what I have direct access to.